### PR TITLE
Fix example crashing and most clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ default = ["ncurses-ext"]
 ncurses-ext = []
 
 [dependencies]
-ncurses = "5.99.0"
+ncurses = "5.101.0"
 const-cstr = "0.3.0"

--- a/examples/event_viewer.rs
+++ b/examples/event_viewer.rs
@@ -2,9 +2,8 @@ extern crate ncurses;
 extern crate terminal_input;
 
 use std::io::Write as _;
-use std::os::raw::c_char;
 
-use terminal_input::{InputStream, Event, Modifiers, KeyInput};
+use terminal_input::{Event, InputStream, KeyInput, Modifiers};
 
 struct Screen(ncurses::WINDOW);
 
@@ -15,7 +14,7 @@ impl Drop for Screen {
 }
 
 fn main() {
-    unsafe { ncurses::ll::setlocale(ncurses::LC_ALL, b"\0".as_ptr() as *const c_char); }
+    ncurses::setlocale(ncurses::LcCategory::all, "");
     let screen = Screen(ncurses::initscr());
     ncurses::scrollok(screen.0, true);
     let stdin = std::io::stdin();
@@ -29,14 +28,14 @@ fn main() {
     loop {
         let event = input_stream.next_event();
         if let Some(ref mut file) = out_file {
-            write!(file, "{:?}\n", event).unwrap();
+            writeln!(file, "{:?}", event).unwrap();
         }
         ncurses::wprintw(screen.0, &format!("{:?}\n", event));
         ncurses::wrefresh(screen.0);
 
         if let Ok(Event::KeyPress { modifiers: Modifiers::CTRL, key: KeyInput::Codepoint('c'), .. })
              | Ok(Event::KeyPress { modifiers: Modifiers::CTRL, key: KeyInput::Codepoint('q'), .. }) = event {
-            return;         
+            return;
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ impl<'a> InputStream<'a> {
     pub unsafe fn init_with_ncurses(data: std::io::StdinLock<'a>, screen: ncurses::ll::WINDOW) -> InputStream<'a> {
         InputStream {
             inner: imp_ncurses::InputStream::init(screen),
-            screen: screen,
+            screen,
             _stdin_lock: data
         }
     }


### PR DESCRIPTION
When trying to build the example, I got a few errors:

```
cargo run --example event_viewer                                                                                                                           ✔ 
   Compiling terminal-input v0.1.0 (/mnt/s/repos/terminal-input)
error[E0425]: cannot find function `setlocale` in module `ncurses::ll`
  --> examples/event_viewer.rs:18:27
   |
18 |     unsafe { ncurses::ll::setlocale(ncurses::LC_ALL, b"\0".as_ptr() as *const c_char); }
   |                           ^^^^^^^^^ not found in `ncurses::ll`
   |
help: consider importing this function
   |
4  | use ncurses::setlocale;
   |
help: if you import `setlocale`, refer to it directly
   |
18 -     unsafe { ncurses::ll::setlocale(ncurses::LC_ALL, b"\0".as_ptr() as *const c_char); }
18 +     unsafe { setlocale(ncurses::LC_ALL, b"\0".as_ptr() as *const c_char); }
   | 

For more information about this error, try `rustc --explain E0425`.
error: could not compile `terminal-input` due to previous error
```

Setting the locale to `"\0"` also caused ncurses to panic, so changed it to the default locale `"C"` instead.

Clippy also reported quite a few warnings that were easy to fix, so I did that as well.

All of this was tested on rust stable 1.63.0:

```
$ rustc --version
rustc 1.63.0 (4b91a6ea7 2022-08-08)
$ cargo --version
cargo 1.63.0 (fd9c4297c 2022-07-01)
```